### PR TITLE
chore: update .mailmap bots

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -15,3 +15,4 @@ Bot <bot@noreply.github.com> <1082092+cubic-dev-ai[bot]@users.noreply.github.com
 Bot <bot@noreply.github.com> <158243242+devin-ai-integration[bot]@users.noreply.github.com>
 Bot <bot@noreply.github.com> <198982749+Copilot@users.noreply.github.com>
 Bot <bot@noreply.github.com> <161369871+google-labs-jules[bot]@users.noreply.github.com>
+Bot <bot@noreply.github.com> <noreply@github.com>


### PR DESCRIPTION
This PR updates the `.mailmap` file to include the `GitHub <noreply@github.com>` identity, ensuring it is correctly mapped to the general `Bot` contributor identity. This was identified by auditing the full Git history (after performing an unshallow fetch) and comparing against existing entries in `.mailmap`.

---
*PR created automatically by Jules for task [6923948318353405271](https://jules.google.com/task/6923948318353405271) started by @RainPPR*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map GitHub <noreply@github.com> to the unified `Bot <bot@noreply.github.com>` identity in `.mailmap` to consolidate bot commits. This ensures consistent attribution in `git shortlog` and blame across the repo.

<sup>Written for commit 2de65120a519d244f5a46c113ecd4282dcc24e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/raineblog/whk/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

